### PR TITLE
fix: allowed Python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -84,5 +84,5 @@ tests = ["pytest", "pytest-cov"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.12"
-content-hash = "32d8873279688c4ae53ef42e07ee6b4864f1ca67fff45ddc08e9dd32025aab12"
+python-versions = "^3.9"
+content-hash = "bca798f69da672a63893c77abd08be66532bff5cc9e6c8c30a134429a6b0e878"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = "^3.9"
 halo = "^0.0.31"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Many of our projects use python = "^3.x" which then results in the following error while locking the dependencies.

The current project's Python requirement (>=3.11,<4.0) is not compatible with some of the required packages Python requirement:
  - scrubadubdub requires Python >=3.9,<3.12, so it will not be satisfied for Python >=3.12,<4.0

cc: @mrshu